### PR TITLE
use raster::predict, implement multi-core processing for rasters

### DIFF
--- a/4_predictModelToStudyArea.R
+++ b/4_predictModelToStudyArea.R
@@ -15,7 +15,7 @@ loc_scripts <- "K:/Reg5Modeling_Project/scripts/Regional_SDM"
 # get paths, other settings
 source(paste(loc_scripts,"0_pathsAndSettings.R", sep="/"))
 # get the customized version of the predict function
-source(paste(loc_scripts, "RasterPredictMod.R", sep = "/"))
+# source(paste(loc_scripts, "RasterPredictMod.R", sep = "/"))
 
 # load data ----
 # get the rdata file
@@ -36,11 +36,28 @@ envStack <- stack(fullL)
 
 # run prediction ----
 fileNm <- paste(loc_outRas, "/", ElementNames$Code, "_",Sys.Date(),".tif", sep = "")
-outRas <- predictRF(envStack, rf.full, progress="text", index=2, na.rm=TRUE, type="prob", filename=fileNm, format = "GTiff", overwrite=TRUE)
 
-#writeRaster(outRas, filename=paste(fileNm, "_2",sep=""), format = "GTiff", overwrite = TRUE)
+# outRas <- predictRF(envStack, rf.full, progress="text", index=2, na.rm=TRUE, type="prob", filename=fileNm, format = "GTiff", overwrite=TRUE)
+# use parallel processing if packages installed
+if (all(c("snow","parallel") %in% installed.packages())) {
+  try({
+    beginCluster(type = "SOCK")
+    outRas <- clusterR(envStack, predict, args = list(model=rf.full, type = "prob", index = 2), verbose = T)
+    writeRaster(outRas, filename = fileNm, format = "GTiff", overwrite = TRUE)
+  })
+  try(endCluster())
+  if (!exists("outRas")) {
+    cat("Cluster processing failed. Falling back to single-core processing...\n")
+    outRas <- predict(object=envStack, model=rf.full, type = "prob", index=2,
+                      filename=fileNm, format = "GTiff", overwrite=TRUE)
+  }
+# otherwise regular processing
+} else {
+  cat("Using single-core processing for prediction.\nInstall package 'snow' for faster cluster (multi-core) processing.\n")
+  outRas <- predict(object=envStack, model=rf.full, type = "prob", index=2,
+                    filename=fileNm, format = "GTiff", overwrite=TRUE)
+}
 
 ## clean up ----
 # remove all objects before moving on to the next script
 rm(list=ls())
-

--- a/4b_thresholdModel.R
+++ b/4b_thresholdModel.R
@@ -215,12 +215,25 @@ m <- cbind(
   to = c(threshold, Inf),
   becomes = c(0, 1)
 )
-
-rasrc <- reclassify(ras, m)
+# reclassify (multi-core try)
+if (all(c("snow","parallel") %in% installed.packages())) {
+  try({
+    cat("Using multi-core processing...\n")
+    beginCluster(type = "SOCK")
+    rasrc <- clusterR(ras, reclassify, args = list(rcl = m))
+  })
+  try(endCluster())
+  if (!exists("rasrc")) {
+    cat("Cluster processing failed. Falling back to single-core processing...\n")
+    rasrc <- reclassify(ras, m)
+  }
+} else {
+  rasrc <- reclassify(ras, m)
+}
 
 #plot(rasrc)
 outfile <- paste(loc_outRas,"/",ElementNames$Code,"_threshold.tif", sep = "")
-writeRaster(rasrc, filename=outfile, format="GTiff", overwrite=TRUE)
+writeRaster(rasrc, filename=outfile, format="GTiff", overwrite=TRUE, datatype = "INT2U")
 
 #clean up
 rm(m, rasrc)
@@ -233,7 +246,21 @@ m <- cbind(
   becomes = c(NA)
 )
 
-rasrc <- reclassify(ras, m)
+# reclassify (multi-core try)
+if (all(c("snow","parallel") %in% installed.packages())) {
+  try({
+    cat("Using multi-core processing...\n")
+    beginCluster(type = "SOCK")
+    rasrc <- clusterR(ras, reclassify, args = list(rcl = m))
+  })
+  try(endCluster())
+  if (!exists("rasrc")) {
+    cat("Cluster processing failed. Falling back to single-core processing...\n")
+    rasrc <- reclassify(ras, m)
+  }
+} else {
+  rasrc <- reclassify(ras, m)
+}
 
 #plot(rasrc)
 outfile <- paste(loc_outRas,"/",ElementNames$Code,"_thresh2.tif", sep = "")


### PR DESCRIPTION
This implements multi-core processing for raster prediction and thresholding. The originally sourced script 
`RasterPredictMod.R` is also no longer needed due to native handling of RF models by `raster::predict`.

Make sure to update/install necessary packages for this update:
```
install.packages(c("snow","raster"))
```